### PR TITLE
Skyshards Guide

### DIFF
--- a/GuideMenu.lua
+++ b/GuideMenu.lua
@@ -393,6 +393,9 @@ function GuideMenu:RefreshUI()
 		local folderslash = self.folder == "" and "" or self.folder.."/"
 		for _,guide in pairs(ZGV.registeredguides) do
 			local wholefolder,topfolder = guide.title:match("LEVELING/("..folderslash.."([^/]+))/.+")
+			if not topfolder then
+				wholefolder,topfolder = guide.title:match("MISCELLANEOUS/("..folderslash.."([^/]+))/.+")
+			end
 			if topfolder then
 				if not topfolders_seen[topfolder] then
 					topfolders_seen[topfolder] = true
@@ -402,7 +405,7 @@ function GuideMenu:RefreshUI()
 		end
 
 		for _,guide in pairs(ZGV.registeredguides) do
-			if (guide.title:match("^LEVELING/"..folderslash.."[^/]+$")) then
+			if (guide.title:match("^LEVELING/"..folderslash.."[^/]+$") or guide.title:match("^MISCELLANEOUS/"..folderslash.."[^/]+$")) then
 				table.insert(guides,guide)
 			end
 		end

--- a/Guides/Skyshards.lua
+++ b/Guides/Skyshards.lua
@@ -5,7 +5,7 @@
 local ZGV = _G.ZGV
 ZGV.GuideMenuTier = "TAM"
 
-ZGV:RegisterGuide("TEST\\Skyshards",[[
+ZGV:RegisterGuide("MISCELLANEOUS\\Miscellaneous\\Testing\\Skyshards",[[
 
 --// Ebonheart Pact
 //Bleakrock Isle

--- a/Guides/Skyshards.lua
+++ b/Guides/Skyshards.lua
@@ -602,7 +602,7 @@ ZGV:RegisterGuide("MISCELLANEOUS\\Miscellaneous\\Testing\\Skyshards",[[
 		.' Go _up the stairs_ and to the _left_ to the _large metal door to leave the temple_ |goto 43.02,86.73 < 10
 		.' Continue along the _snowy path, staying close to the fires_ as you go |goto therift_base 76.96,60.26 < 20
 		.click Skyshard##3360010 |achieve 689/8 |goto 78.22,62.00
-		|only if completedquest("A Walk Above the Clouds##163051/14")
+		|only if ZGV.Quests:IsQuestComplete("A Walk Above the Clouds")
 	step
 		'Open your map, and teleport to the _Riften Wayshrine_ in the eastern portion of The Rift |goto riften_base 71.28,53.54  |achieve 689/9
 		.' Follow the path and _leave through the opening_ |goto riften_base 65.18,34.29 < 20

--- a/Guides/Skyshards.lua
+++ b/Guides/Skyshards.lua
@@ -13,7 +13,7 @@ ZGV:RegisterGuide("MISCELLANEOUS\\Miscellaneous\\Testing\\Skyshards",[[
 		'Open your map, and teleport to the _Bleakrock Wayshrine_ in the center of Bleakrock Isle |goto bleakrock_base 49.31,38.55  |achieve 398
 		.' Follow the road and _cross the bridge_ |goto bleakrock_base 44.96,40.92 < 20
 		.' Take the _left fork_ in the road |goto bleakrock_base 38.22,39.52 < 20
-		.' Enter _Hozzin's Folly_ |gmoto 25.46,39.66 < 5
+		.' Enter _Hozzin's Folly_ |goto 25.46,39.66 < 5
 		.' Follow the _path inside the cave_ to the skyshard |goto hozzinsfolley_base 55.93,76.13
 		.click Skyshard##3360010 |achieve 398/3 |goto hozzinsfolley_base 32.91,81.56
 	step


### PR DESCRIPTION
This pull request will create a new type of guide called "MISCELLANEOUS" and implements code to support/display those guides in the menu.  _(Please note that, right now, only guides of type "LEVELING" were being displayed in the menu.)_

It also moves the Skyshards Guide to this category and then places it within the following folder in the menu:  "Miscellaneous/Testing/Skyshards".

This pull request also corrects an error in the Skyshards Guide caused by a typo as well as an error caused by calling a parser function no longer supported.

Finally, please note that I did not test the Skyshards Guide at all other than to fix bugs.   But, it should be ready for testing and filling out with all the other zones in the game.